### PR TITLE
Fix: Add type check for baseline_results

### DIFF
--- a/launch_scientist.py
+++ b/launch_scientist.py
@@ -171,7 +171,9 @@ def do_idea(
     shutil.copytree(base_dir, destination_dir, dirs_exist_ok=True)
     with open(osp.join(base_dir, "run_0", "final_info.json"), "r") as f:
         baseline_results = json.load(f)
-    baseline_results = {k: v["means"] for k, v in baseline_results.items()}
+    # Check if baseline_results is a dictionary before extracting means
+    if isinstance(baseline_results, dict):
+        baseline_results = {k: v["means"] for k, v in baseline_results.items()}
     exp_file = osp.join(folder_name, "experiment.py")
     vis_file = osp.join(folder_name, "plot.py")
     notes = osp.join(folder_name, "notes.txt")


### PR DESCRIPTION
## Summary
- Add type check for `baseline_results` in the `do_idea` function to fix potential errors when processing different types of baseline results
- Ensures the code can handle both dictionary and non-dictionary baseline results formats

## Test plan
- Verified the code handles both dictionary and non-dictionary baseline results
- No regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)